### PR TITLE
ensure that type is always serialized

### DIFF
--- a/src/commonMain/kotlin/com/jillesvangurp/geo/geojson.kt
+++ b/src/commonMain/kotlin/com/jillesvangurp/geo/geojson.kt
@@ -3,6 +3,7 @@
 package com.jillesvangurp.geo
 
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -80,6 +81,7 @@ fun BoundingBox.polygon(): Geometry.PolygonGeometry {
 
 @Serializable(with = Geometry.Companion::class)
 sealed class Geometry {
+    @Required
     abstract val type: GeometryType
 
     fun asFeature(properties: JsonObject? = null, bbox: BoundingBox? = null) =


### PR DESCRIPTION
required ensures that it is always serialized, even if serialization is configured t skip default values