### PR TITLE
Add assertions for polygon test

### DIFF
--- a/src/commonTest/kotlin/com/jillesvangurp/geogeometry/GeoGeometryMigratedTests.kt
+++ b/src/commonTest/kotlin/com/jillesvangurp/geogeometry/GeoGeometryMigratedTests.kt
@@ -31,6 +31,7 @@ import com.jillesvangurp.geojson.geoJsonIOUrl
 import com.jillesvangurp.geojson.latitude
 import com.jillesvangurp.geojson.longitude
 import com.jillesvangurp.geojson.polygonGeometry
+import com.jillesvangurp.serializationext.DEFAULT_JSON
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.withClue
@@ -238,7 +239,16 @@ class GeoGeometryMigratedTests {
         buf.deleteAt(buf.length - 1)
         buf.append("]")
 
-        // FIXME complete test
+        // verify resulting polygon
+        polygon.size shouldBeGreaterThan 2
+
+        // buf should contain valid JSON representing the polygon
+        DEFAULT_JSON.parseToJsonElement(buf.toString()).jsonArray.size shouldBe polygon.size
+
+        // a point inside should be contained and an external point should not
+        val center = polygonCenter(*polygon)
+        polygonContains(center.latitude, center.longitude, *polygon) shouldBe true
+        polygonContains(0.0, 0.0, *polygon) shouldBe false
     }
 
     @Test


### PR DESCRIPTION
## Summary
- extend polygon test in GeoGeometryMigratedTests
- parse polygon string as JSON via DEFAULT_JSON constant

## Testing
- `./gradlew jvmTest --no-daemon` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841c55fcafc832ea6aeba21154a06ec