### PR TITLE
Refactor geometry packages

### DIFF
--- a/src/commonMain/kotlin/com/jillesvangurp/geo/GeoHashUtils.kt
+++ b/src/commonMain/kotlin/com/jillesvangurp/geo/GeoHashUtils.kt
@@ -18,8 +18,7 @@
  */
 package com.jillesvangurp.geo
 
-import com.jillesvangurp.geo.GeoGeometry.Companion.overlap
-import com.jillesvangurp.geo.GeoGeometry.Companion.polygonContains
+import com.jillesvangurp.geogeometry.geometry.*
 import com.jillesvangurp.geojson.*
 import kotlin.math.min
 
@@ -98,7 +97,7 @@ class GeoHashUtils {
             if (length < 1 || length > 12) {
                 throw IllegalArgumentException("length must be between 1 and 12")
             }
-            GeoGeometry.validate(latitude, longitude, false)
+            validate(latitude, longitude, false)
             val latInterval = doubleArrayOf(-90.0, 90.0)
             val lonInterval = doubleArrayOf(-180.0, 180.0)
 
@@ -197,7 +196,7 @@ class GeoHashUtils {
          * The original apache code attempted to round the returned coordinate. I have chosen to remove this 'feature' since
          * it is useful to know the center of the geo hash as exactly as possible, even for very short geo hashes.
          *
-         * Should you wish to apply some rounding, you can use the GeoGeometry.roundToDecimals method.
+         * Should you wish to apply some rounding, you can use the roundToDecimals method.
          *
          * @param geoHash valid geo hash
          * @return a coordinate representing the center of the geohash as a double array of [longitude,latitude]
@@ -287,7 +286,7 @@ class GeoHashUtils {
          */
 
         fun contains(geoHash: String, latitude: Double, longitude: Double): Boolean {
-            return GeoGeometry.bboxContains(decodeBbox(geoHash), latitude, longitude)
+            return bboxContains(decodeBbox(geoHash), latitude, longitude)
         }
 
         /**
@@ -506,7 +505,7 @@ class GeoHashUtils {
                     throw IllegalArgumentException("maxLength should be between 2 and $DEFAULT_GEO_HASH_LENGTH was $maxLength")
                 }
             }
-            val bbox = GeoGeometry.boundingBox(coordinates)
+            val bbox = boundingBox(coordinates)
             // first lets figure out an appropriate geohash length
 
             // if shit breaks, this is useful for wtf'ing in geojson.io
@@ -520,7 +519,7 @@ class GeoHashUtils {
             val westLon = bbox.westLongitude
             val eastLon = bbox.eastLongitude
 
-            val diagonal = GeoGeometry.distance(southLat, westLon, northLat, eastLon)
+            val diagonal = distance(southLat, westLon, northLat, eastLon)
             val hashLength = min(
                 maxLength ?: 12,
                 suitableHashLength(diagonal, southLat, westLon) + 1
@@ -823,7 +822,7 @@ class GeoHashUtils {
             includePartial: Boolean = false,
             segments: Int = 20
         ): Set<String> {
-            val circle2polygon = GeoGeometry.circle2polygon(segments, latitude, longitude, radius)
+            val circle2polygon = circle2polygon(segments, latitude, longitude, radius)
             return geoHashesForLinearRing(
                 maxLength = maxLength,
                 coordinates = circle2polygon[0],
@@ -846,7 +845,7 @@ class GeoHashUtils {
                 length = hash.length
                 val bbox = decodeBbox(hash)
                 width =
-                    GeoGeometry.distance(
+                    distance(
                         lat1 = bbox.northLatitude,
                         long1 = bbox.westLongitude,
                         lat2 = bbox.northLatitude,

--- a/src/commonMain/kotlin/com/jillesvangurp/geo/concave-hull.kt
+++ b/src/commonMain/kotlin/com/jillesvangurp/geo/concave-hull.kt
@@ -1,8 +1,9 @@
 package com.jillesvangurp.geo
 
-import com.jillesvangurp.geojson.PointCoordinates
+import com.jillesvangurp.geogeometry.core.PointCoordinates
 import com.jillesvangurp.geojson.latitude
 import com.jillesvangurp.geojson.longitude
+import com.jillesvangurp.geogeometry.geometry.*
 import kotlin.math.*
 
 /**
@@ -38,7 +39,7 @@ import kotlin.math.*
 //}
 
 private fun kNearestNeighbors(l: List<PointCoordinates>, q: PointCoordinates, k: Int): List<PointCoordinates> {
-    return l.map { o -> Pair(GeoGeometry.distance(q, o), o) }
+    return l.map { o -> Pair(distance(q, o), o) }
         .sortedBy { it.first }
         .take(k)
         .map { it.second }
@@ -153,7 +154,7 @@ tailrec fun calculateConcaveHull(ps: List<PointCoordinates>, k: Int, recurseCoun
             var j = 2
             its = false
             while (!its && j < concaveHull.size - lastPoint) {
-                its = GeoGeometry.linesCross(
+                its = linesCross(
                     concaveHull[step - 2],
                     clockwisePoints[i],
                     concaveHull[step - 2 - j],
@@ -184,7 +185,7 @@ tailrec fun calculateConcaveHull(ps: List<PointCoordinates>, k: Int, recurseCoun
     var i: Int = mutablePoints.size - 1
     while (insideCheck && i > 0) {
 //        insideCheck = pointInPolygon(mutablePoints[i], concaveHull)
-        insideCheck = GeoGeometry.polygonContains(mutablePoints[i], concaveHull.toTypedArray())
+        insideCheck = polygonContains(mutablePoints[i], concaveHull.toTypedArray())
         i--
     }
 

--- a/src/commonMain/kotlin/com/jillesvangurp/geo/tiles/Tile.kt
+++ b/src/commonMain/kotlin/com/jillesvangurp/geo/tiles/Tile.kt
@@ -2,8 +2,8 @@ package com.jillesvangurp.geo.tiles
 
 import com.jillesvangurp.geo.tiles.Tile.Companion.MAX_ZOOM
 import com.jillesvangurp.geo.tiles.Tile.Companion.coordinateToTile
-import com.jillesvangurp.geojson.BoundingBox
-import com.jillesvangurp.geojson.PointCoordinates
+import com.jillesvangurp.geogeometry.core.BoundingBox
+import com.jillesvangurp.geogeometry.core.PointCoordinates
 import com.jillesvangurp.geojson.bottomRight
 import com.jillesvangurp.geojson.latitude
 import com.jillesvangurp.geojson.longitude

--- a/src/commonMain/kotlin/com/jillesvangurp/geo/utm.kt
+++ b/src/commonMain/kotlin/com/jillesvangurp/geo/utm.kt
@@ -12,10 +12,8 @@ package com.jillesvangurp.geo
  * Permission to use, copy, modify, and distribute this software is
  * freely granted, provided that this notice is preserved.
  */
-import com.jillesvangurp.geo.GeoGeometry.Companion.fromRadians
-import com.jillesvangurp.geo.GeoGeometry.Companion.roundDecimals
-import com.jillesvangurp.geo.GeoGeometry.Companion.toRadians
-import com.jillesvangurp.geojson.PointCoordinates
+import com.jillesvangurp.geogeometry.geometry.*
+import com.jillesvangurp.geogeometry.core.PointCoordinates
 import com.jillesvangurp.geojson.latitude
 import com.jillesvangurp.geojson.longitude
 import com.jillesvangurp.geojson.normalize

--- a/src/commonMain/kotlin/com/jillesvangurp/geo/vicenty.kt
+++ b/src/commonMain/kotlin/com/jillesvangurp/geo/vicenty.kt
@@ -37,9 +37,8 @@
 
 package com.jillesvangurp.geo
 
-import com.jillesvangurp.geo.GeoGeometry.Companion.fromRadians
-import com.jillesvangurp.geo.GeoGeometry.Companion.toRadians
-import com.jillesvangurp.geojson.PointCoordinates
+import com.jillesvangurp.geogeometry.geometry.*
+import com.jillesvangurp.geogeometry.core.PointCoordinates
 import com.jillesvangurp.geojson.latitude
 import com.jillesvangurp.geojson.longitude
 import kotlin.math.*

--- a/src/commonMain/kotlin/com/jillesvangurp/geogeometry/core/Types.kt
+++ b/src/commonMain/kotlin/com/jillesvangurp/geogeometry/core/Types.kt
@@ -1,0 +1,27 @@
+package com.jillesvangurp.geogeometry.core
+
+import kotlin.math.PI
+
+// Types previously in geojson.kt
+
+typealias PointCoordinates = DoubleArray
+/**
+ * Lowest axes followed by highest axes
+ * BoundingBox = [westLongitude,southLatitude,eastLongitude,northLatitude]
+ */
+typealias BoundingBox = DoubleArray
+
+typealias MultiPointCoordinates = Array<PointCoordinates>
+typealias LineStringCoordinates = Array<PointCoordinates>
+typealias LinearRingCoordinates = Array<PointCoordinates>
+typealias MultiLineStringCoordinates = Array<LineStringCoordinates> // Outer polygon + holes
+typealias PolygonCoordinates = Array<LinearRingCoordinates> // Outer polygon + holes
+typealias MultiPolygonCoordinates = Array<PolygonCoordinates>
+
+// Constants previously defined in GeoGeometry
+const val EARTH_RADIUS_METERS = 6371000.0
+const val WGS84_RADIUS = 6378137.0
+const val EARTH_CIRCUMFERENCE_METERS = EARTH_RADIUS_METERS * PI * 2.0
+const val DEGREE_LATITUDE_METERS = EARTH_RADIUS_METERS * PI / 180.0
+const val DEGREES_TO_RADIANS = PI / 180.0
+const val RADIANS_TO_DEGREES = 1.0 / DEGREES_TO_RADIANS

--- a/src/commonMain/kotlin/com/jillesvangurp/geogeometry/geometry/Geometry.kt
+++ b/src/commonMain/kotlin/com/jillesvangurp/geogeometry/geometry/Geometry.kt
@@ -21,8 +21,9 @@
  */
 @file:Suppress("MemberVisibilityCanBePrivate")
 
-package com.jillesvangurp.geo
+package com.jillesvangurp.geogeometry.geometry
 
+import com.jillesvangurp.geogeometry.core.*
 import com.jillesvangurp.geojson.*
 import com.jillesvangurp.geojson.latitude
 import com.jillesvangurp.geojson.longitude
@@ -50,22 +51,6 @@ import kotlin.math.*
  * It should also be noted that this class contains several methods that treat 2d arrays as polygons.
  */
 @Suppress("unused")
-class GeoGeometry {
-
-    companion object {
-        /**
-         * Earth's mean radius, in meters.
-         *
-         * see http://en.wikipedia.org/wiki/Earth%27s_radius#Mean_radii
-         */
-        // this value is approximated to account for the fact that the world is not a perfect sphere
-        const val EARTH_RADIUS_METERS = 6371000.0
-        const val WGS84_RADIUS = 6378137
-        const val EARTH_CIRCUMFERENCE_METERS = EARTH_RADIUS_METERS * PI * 2.0
-        const val DEGREE_LATITUDE_METERS = EARTH_RADIUS_METERS * PI / 180.0
-        const val DEGREES_TO_RADIANS =  PI / 180.0
-        const val RADIANS_TO_DEGREES = 1.0 / DEGREES_TO_RADIANS
-
 
         /**
          * @param pointCoordinates point
@@ -1535,7 +1520,4 @@ class GeoGeometry {
                 }
                 .toList()
         }
-    }
-}
-
 

--- a/src/commonMain/kotlin/com/jillesvangurp/geojson/geojson-extensions.kt
+++ b/src/commonMain/kotlin/com/jillesvangurp/geojson/geojson-extensions.kt
@@ -1,6 +1,6 @@
 package com.jillesvangurp.geojson
 
-import com.jillesvangurp.geo.GeoGeometry
+import com.jillesvangurp.geogeometry.geometry.*
 
 fun LineStringCoordinates.centroid(): DoubleArray {
     var minLon = 180.0
@@ -25,30 +25,30 @@ fun MultiPolygonCoordinates.centroid() = this.map { it.centroid() }.toTypedArray
 fun Geometry.centroid(): PointCoordinates = centroidOrNull()
 
 fun Geometry.centroidOrNull(): PointCoordinates = when (this) {
-    is Geometry.Point -> this.coordinates ?: GeoGeometry.polygonCenter(bbox!!)
-    is Geometry.LineString -> this.coordinates?.centroid() ?: GeoGeometry.polygonCenter(bbox!!)
-    is Geometry.MultiLineString -> this.coordinates?.centroid() ?: GeoGeometry.polygonCenter(bbox!!)
-    is Geometry.Polygon -> this.coordinates?.centroid() ?: GeoGeometry.polygonCenter(bbox!!)
-    is Geometry.MultiPolygon -> this.coordinates?.centroid() ?: GeoGeometry.polygonCenter(bbox!!)
-    is Geometry.MultiPoint -> this.coordinates?.centroid() ?: GeoGeometry.polygonCenter(bbox!!)
+    is Geometry.Point -> this.coordinates ?: polygonCenter(bbox!!)
+    is Geometry.LineString -> this.coordinates?.centroid() ?: polygonCenter(bbox!!)
+    is Geometry.MultiLineString -> this.coordinates?.centroid() ?: polygonCenter(bbox!!)
+    is Geometry.Polygon -> this.coordinates?.centroid() ?: polygonCenter(bbox!!)
+    is Geometry.MultiPolygon -> this.coordinates?.centroid() ?: polygonCenter(bbox!!)
+    is Geometry.MultiPoint -> this.coordinates?.centroid() ?: polygonCenter(bbox!!)
     is Geometry.GeometryCollection -> {
         this.geometries.map { it.centroidOrNull() }.toTypedArray().centroid()
     }
 }
 
-fun PointCoordinates.translate(latDistance: Double, lonDistance: Double): PointCoordinates = GeoGeometry.translate(this.latitude, this.longitude, latDistance, lonDistance)
+fun PointCoordinates.translate(latDistance: Double, lonDistance: Double): PointCoordinates = translate(this.latitude, this.longitude, latDistance, lonDistance)
 fun Array<PointCoordinates>.translate(latDistance: Double, lonDistance: Double): Array<PointCoordinates> = this.map { it.translate(latDistance,lonDistance) }.toTypedArray()
 fun PolygonCoordinates.translate(latDistance: Double, lonDistance: Double): PolygonCoordinates = this.map { it.translate(latDistance,lonDistance) }.toTypedArray()
 fun MultiPolygonCoordinates.translate(latDistance: Double, lonDistance: Double): MultiPolygonCoordinates = this.map { it.translate(latDistance,lonDistance) }.toTypedArray()
 
 fun Geometry.translate(newCentroid: Geometry.Point): Geometry {
     val oldCentroid = centroid()
-    val compassDirection = GeoGeometry.headingFromTwoPoints(oldCentroid, newCentroid.coordinates!!)
+    val compassDirection = headingFromTwoPoints(oldCentroid, newCentroid.coordinates!!)
     // make sure we handle negative distances correctly
     val latFactor = if(compassDirection>90 && compassDirection<270) -1.0 else 1.0
     val lonFactor = if(compassDirection>180) -1.0 else 1.0
-    val latDistance = latFactor * GeoGeometry.distance(oldCentroid, doubleArrayOf(oldCentroid.longitude, newCentroid.coordinates.latitude))
-    val lonDistance = lonFactor * GeoGeometry.distance(oldCentroid, doubleArrayOf(newCentroid.coordinates.longitude, oldCentroid.latitude))
+    val latDistance = latFactor * distance(oldCentroid, doubleArrayOf(oldCentroid.longitude, newCentroid.coordinates.latitude))
+    val lonDistance = lonFactor * distance(oldCentroid, doubleArrayOf(newCentroid.coordinates.longitude, oldCentroid.latitude))
     return translate(latDistance, lonDistance)
 }
 
@@ -74,15 +74,15 @@ fun Geometry.translate(
     }
 }
 
-fun PointCoordinates.distanceTo(pointCoordinates: PointCoordinates) = GeoGeometry.distance(this,pointCoordinates)
-fun PointCoordinates.headingTo(pointCoordinates: PointCoordinates) = GeoGeometry.headingFromTwoPoints(this,pointCoordinates)
+fun PointCoordinates.distanceTo(pointCoordinates: PointCoordinates) = distance(this,pointCoordinates)
+fun PointCoordinates.headingTo(pointCoordinates: PointCoordinates) = headingFromTwoPoints(this,pointCoordinates)
 
 fun Geometry.area() = when(this) {
     is Geometry.Polygon -> {
-        GeoGeometry.area(this.coordinates!!)
+        area(this.coordinates!!)
     }
     is Geometry.MultiPolygon -> this.coordinates?.sumOf {
-        GeoGeometry.area(it)
+        area(it)
     } ?:0.0
     else -> 0.0
 }
@@ -205,7 +205,7 @@ fun PointCoordinates.rotate (degrees: Double, around: PointCoordinates?=null): P
     return if(around == null) {
         this
     } else {
-        GeoGeometry.rotateAround(around, this, degrees)
+        rotateAround(around, this, degrees)
     }
 }
 

--- a/src/commonTest/kotlin/com/jillesvangurp/geo/tiles/TileTest.kt
+++ b/src/commonTest/kotlin/com/jillesvangurp/geo/tiles/TileTest.kt
@@ -1,6 +1,6 @@
 package com.jillesvangurp.geo.tiles
 
-import com.jillesvangurp.geo.GeoGeometry
+import com.jillesvangurp.geogeometry.geometry.*
 import com.jillesvangurp.geo.tiles.Tile.Companion.coordinateToTile
 import com.jillesvangurp.geogeometry.brandenBurgerGate
 import com.jillesvangurp.geogeometry.rosenthalerPlatz
@@ -283,7 +283,7 @@ class TileTest {
 
     @Test
     fun bboxShouldHaveCorrectTiles() {
-        val bbox = GeoGeometry.boundingBox(
+        val bbox = boundingBox(
             arrayOf(
                 rosenthalerPlatz,
                 brandenBurgerGate,

--- a/src/commonTest/kotlin/com/jillesvangurp/geogeometry/GeoGeometryMigratedTests.kt
+++ b/src/commonTest/kotlin/com/jillesvangurp/geogeometry/GeoGeometryMigratedTests.kt
@@ -1,32 +1,8 @@
 package com.jillesvangurp.geogeometry
 
-import com.jillesvangurp.geo.GeoGeometry
-import com.jillesvangurp.geo.GeoGeometry.Companion.area
-import com.jillesvangurp.geo.GeoGeometry.Companion.bbox
-import com.jillesvangurp.geo.GeoGeometry.Companion.bboxContains
-import com.jillesvangurp.geo.GeoGeometry.Companion.boundingBox
-import com.jillesvangurp.geo.GeoGeometry.Companion.circle2polygon
-import com.jillesvangurp.geo.GeoGeometry.Companion.contains
-import com.jillesvangurp.geo.GeoGeometry.Companion.distance
-import com.jillesvangurp.geo.GeoGeometry.Companion.distanceToLine
-import com.jillesvangurp.geo.GeoGeometry.Companion.distanceToLineString
-import com.jillesvangurp.geo.GeoGeometry.Companion.distanceToMultiPolygon
-import com.jillesvangurp.geo.GeoGeometry.Companion.distanceToPolygon
-import com.jillesvangurp.geo.GeoGeometry.Companion.equirectangularDistance
-import com.jillesvangurp.geo.GeoGeometry.Companion.expandPolygon
-import com.jillesvangurp.geo.GeoGeometry.Companion.filterNoiseFromPointCloud
-import com.jillesvangurp.geo.GeoGeometry.Companion.linesCross
-import com.jillesvangurp.geo.GeoGeometry.Companion.overlap
-import com.jillesvangurp.geo.GeoGeometry.Companion.polygonCenter
-import com.jillesvangurp.geo.GeoGeometry.Companion.polygonContains
-import com.jillesvangurp.geo.GeoGeometry.Companion.polygonForPoints
-import com.jillesvangurp.geo.GeoGeometry.Companion.rightTurn
-import com.jillesvangurp.geo.GeoGeometry.Companion.roundToDecimals
-import com.jillesvangurp.geo.GeoGeometry.Companion.simplifyLine
-import com.jillesvangurp.geo.GeoGeometry.Companion.validate
-import com.jillesvangurp.geo.GeoGeometry.Companion.vicentyDistance
+import com.jillesvangurp.geogeometry.geometry.*
 import com.jillesvangurp.geo.GeoHashUtils.Companion.isWest
-import com.jillesvangurp.geojson.PointCoordinates
+import com.jillesvangurp.geogeometry.core.PointCoordinates
 import com.jillesvangurp.geojson.geoJsonIOUrl
 import com.jillesvangurp.geojson.latitude
 import com.jillesvangurp.geojson.longitude
@@ -303,8 +279,8 @@ class GeoGeometryMigratedTests {
         val l2p1 = doubleArrayOf(-71.1884310515, 42.3221529806)
         val l2p2 = doubleArrayOf(-71.1884310517, 42.3222331303)
 
-        GeoGeometry.linesCross(l1p1, l1p2, l2p1, l2p2) shouldBe false
-        GeoGeometry.linesCross(l2p1, l2p2, l1p1, l1p2) shouldBe false
+        linesCross(l1p1, l1p2, l2p1, l2p2) shouldBe false
+        linesCross(l2p1, l2p2, l1p1, l1p2) shouldBe false
     }
 
     @Test
@@ -372,7 +348,7 @@ class GeoGeometryMigratedTests {
 
     @Test
     fun shouldExpandCircle() {
-        val circle = GeoGeometry.circle2polygon(40, rosenthalerPlatz.latitude,rosenthalerPlatz.longitude,5.0)
+        val circle = circle2polygon(40, rosenthalerPlatz.latitude,rosenthalerPlatz.longitude,5.0)
 
         val expandPolygon = expandPolygon(0.5, circle)
 
@@ -810,7 +786,7 @@ class GeoGeometryMigratedTests {
             repeat(1000000) {
                 val point = randomLatLonAwayFromPolesAndDateLine()
                 withClue("${point.latitude}, ${point.longitude}") {
-                    val poly = GeoGeometry.circle2polygon(40, point.latitude, point.longitude, 50.0)
+                    val poly = circle2polygon(40, point.latitude, point.longitude, 50.0)
 
                     polygonContains(point, poly) shouldBe true
                 }

--- a/src/commonTest/kotlin/com/jillesvangurp/geogeometry/GeoGeometryTest.kt
+++ b/src/commonTest/kotlin/com/jillesvangurp/geogeometry/GeoGeometryTest.kt
@@ -1,11 +1,6 @@
 package com.jillesvangurp.geogeometry
 
-import com.jillesvangurp.geo.GeoGeometry
-import com.jillesvangurp.geo.GeoGeometry.Companion.changeOrder
-import com.jillesvangurp.geo.GeoGeometry.Companion.ensureFollowsRightHandSideRule
-import com.jillesvangurp.geo.GeoGeometry.Companion.hasSameStartAndEnd
-import com.jillesvangurp.geo.GeoGeometry.Companion.isValid
-import com.jillesvangurp.geo.GeoGeometry.Companion.roundToDecimals
+import com.jillesvangurp.geogeometry.geometry.*
 import com.jillesvangurp.geojson.Geometry
 import com.jillesvangurp.geojson.degree
 import com.jillesvangurp.geojson.eastOrWest
@@ -52,7 +47,7 @@ class GeoGeometryTest {
             decimalDegrees.minutes shouldBe minutes
             roundToDecimals(decimalDegrees.seconds, 2) shouldBe seconds
 
-            val decimalDegree = GeoGeometry.toDecimalDegree(direction, degrees, minutes, seconds)
+            val decimalDegree = toDecimalDegree(direction, degrees, minutes, seconds)
             abs(decimalDegree - decimalDegrees) shouldBeLessThan 0.00001
         }
     }
@@ -102,11 +97,11 @@ class GeoGeometryTest {
 
     @Test
     fun headingFromTwoPoints() {
-        GeoGeometry.headingFromTwoPoints(
+        headingFromTwoPoints(
             doubleArrayOf(13.0, 52.0),
             doubleArrayOf(14.0, 53.0)
         ).roundToLong() shouldBe 31
-        GeoGeometry.headingFromTwoPoints(
+        headingFromTwoPoints(
             doubleArrayOf(14.0, 53.0),
             doubleArrayOf(13.0, 52.0)
         ).roundToLong() shouldBe 212
@@ -114,19 +109,19 @@ class GeoGeometryTest {
 
     @Test
     fun headingFromTwoPointsShouldBeBetweenZeroAnd360() {
-        GeoGeometry.headingFromTwoPoints(
+        headingFromTwoPoints(
             doubleArrayOf(13.0, 52.0),
             doubleArrayOf(13.0, 52.0001)
         ).roundToLong() shouldBe 0
-        GeoGeometry.headingFromTwoPoints(
+        headingFromTwoPoints(
             doubleArrayOf(12.999, 52.0),
             doubleArrayOf(13.0, 52.0)
         ).roundToLong() shouldBe 90
-        GeoGeometry.headingFromTwoPoints(
+        headingFromTwoPoints(
             doubleArrayOf(13.0, 52.0001),
             doubleArrayOf(13.0, 52.0)
         ).roundToLong() shouldBe 180
-        GeoGeometry.headingFromTwoPoints(
+        headingFromTwoPoints(
             doubleArrayOf(13.0, 52.0),
             doubleArrayOf(12.999, 52.0)
         ).roundToLong() shouldBe 270
@@ -186,9 +181,9 @@ class GeoGeometryTest {
                 "40.7128,, -74.0060" to null,
                 "40.7128, -74.0060," to null,
             ).forEach { (input, expected) ->
-                val parsed = GeoGeometry.parseCoordinate(input)
+                val parsed = parseCoordinate(input)
                 parsed shouldBe expected
-                GeoGeometry.isValidCoordinate(input) shouldBe (parsed != null)
+                isValidCoordinate(input) shouldBe (parsed != null)
             }
         }
     }
@@ -203,7 +198,7 @@ class GeoGeometryTest {
             185,13
         """.trimIndent()
 
-        GeoGeometry.findAllCoordinates(textWithValidAndInvalid) shouldContainExactly listOf(
+        findAllCoordinates(textWithValidAndInvalid) shouldContainExactly listOf(
             doubleArrayOf(-74.0060, 40.7128),
             doubleArrayOf(2.3522, 48.8566),
             doubleArrayOf(0.0, 0.0),
@@ -211,10 +206,10 @@ class GeoGeometryTest {
         )
 
         // Only invalid
-        GeoGeometry.findAllCoordinates("junk 91,0; 1000,1000 text") shouldBe emptyList()
+        findAllCoordinates("junk 91,0; 1000,1000 text") shouldBe emptyList()
 
         // Empty input
-        GeoGeometry.findAllCoordinates("") shouldBe emptyList()
+        findAllCoordinates("") shouldBe emptyList()
     }
 }
 

--- a/src/commonTest/kotlin/com/jillesvangurp/geogeometry/GeoHashUtilsTest.kt
+++ b/src/commonTest/kotlin/com/jillesvangurp/geogeometry/GeoHashUtilsTest.kt
@@ -1,10 +1,10 @@
 package com.jillesvangurp.geogeometry
 
-import com.jillesvangurp.geo.GeoGeometry
+import com.jillesvangurp.geogeometry.geometry.*
 import com.jillesvangurp.geo.GeoHashUtils
 import com.jillesvangurp.geojson.FeatureCollection
 import com.jillesvangurp.geojson.Geometry
-import com.jillesvangurp.geojson.PolygonCoordinates
+import com.jillesvangurp.geogeometry.core.PolygonCoordinates
 import com.jillesvangurp.geojson.eastLongitude
 import com.jillesvangurp.geojson.latitude
 import com.jillesvangurp.geojson.longitude
@@ -127,8 +127,8 @@ class GeoHashUtilsTest {
         println(hashes.size)
         println(DEFAULT_JSON.encodeToString(FeatureCollection.serializer(), FeatureCollection.fromGeoHashes(hashes)))
 
-        val totalHashedArea = hashes.map { GeoHashUtils.decodeBbox(it) }.sumOf { GeoGeometry.area(it) }
-        val bboxArea = GeoGeometry.area(GeoGeometry.boundingBox(p.coordinates as PolygonCoordinates))
+        val totalHashedArea = hashes.map { GeoHashUtils.decodeBbox(it) }.sumOf { area(it) }
+        val bboxArea = area(boundingBox(p.coordinates as PolygonCoordinates))
         // it's a concave polygon so the area of the hashes should be smaller than that of the
         // bounding box containing the polygon
         totalHashedArea shouldBeLessThan bboxArea
@@ -344,7 +344,7 @@ class GeoHashUtilsTest {
                     val length = GeoHashUtils.suitableHashLength(granularity, latitude, longitude)
                     val hash = GeoHashUtils.encode(latitude = latitude, longitude = longitude, length = length)
                     val bbox = GeoHashUtils.decodeBbox(hash)
-                    val distance = GeoGeometry.distance(bbox[0], bbox[1], bbox[0], bbox[3])
+                    val distance = distance(bbox[0], bbox[1], bbox[0], bbox[3])
                     distance shouldBeLessThan granularity
                 }
             }
@@ -398,7 +398,7 @@ class GeoHashUtilsTest {
             GeoHashUtils.geoHashesForCircle(6, 52.0, 13.0, 200.0)
         for (hash in hashesForCircle) {
             val point = GeoHashUtils.decode(hash)
-            val distance = GeoGeometry.distance(point, lonLat(13.0, 52.0))
+            val distance = distance(point, lonLat(13.0, 52.0))
             distance shouldBeLessThan 200.0
         }
     }
@@ -458,7 +458,7 @@ class GeoHashUtilsTest {
         println(DEFAULT_JSON.encodeToString(FeatureCollection.serializer(), FeatureCollection.fromGeoHashes(hashes)))
         println(hashes.size)
         for (hash in hashes) {
-            GeoGeometry.distance(
+            distance(
                 GeoHashUtils.decode(
                     hash
                 ),
@@ -487,11 +487,11 @@ class GeoHashUtilsTest {
             lonLat(52.0, 12.0),
             lonLat(51.0, 12.0)
         )
-        GeoGeometry.overlap(polygon, polygon) shouldBe true
-        GeoGeometry.overlap(polygon, p2overlapping) shouldBe true
-        GeoGeometry.overlap(p2overlapping, polygon) shouldBe true
-        GeoGeometry.overlap(polygon, p4inside) shouldBe true
-        GeoGeometry.overlap(p4inside, polygon) shouldBe true
+        overlap(polygon, polygon) shouldBe true
+        overlap(polygon, p2overlapping) shouldBe true
+        overlap(p2overlapping, polygon) shouldBe true
+        overlap(polygon, p4inside) shouldBe true
+        overlap(p4inside, polygon) shouldBe true
     }
 
     @Test

--- a/src/commonTest/kotlin/com/jillesvangurp/geogeometry/MGRSTest.kt
+++ b/src/commonTest/kotlin/com/jillesvangurp/geogeometry/MGRSTest.kt
@@ -1,7 +1,7 @@
 package com.jillesvangurp.geogeometry
 
 import com.jillesvangurp.geo.*
-import com.jillesvangurp.geo.GeoGeometry.Companion.roundDecimals
+import com.jillesvangurp.geogeometry.geometry.*
 import com.jillesvangurp.geojson.distanceTo
 import com.jillesvangurp.geojson.latitude
 import com.jillesvangurp.geojson.longitude

--- a/src/commonTest/kotlin/com/jillesvangurp/geogeometry/MapAlignmentTest.kt
+++ b/src/commonTest/kotlin/com/jillesvangurp/geogeometry/MapAlignmentTest.kt
@@ -1,7 +1,6 @@
 package com.jillesvangurp.geogeometry
 
-import com.jillesvangurp.geo.GeoGeometry
-import com.jillesvangurp.geo.GeoGeometry.Companion.roundDecimals
+import com.jillesvangurp.geogeometry.geometry.*
 import com.jillesvangurp.geojson.FeatureCollection
 import com.jillesvangurp.geojson.Geometry
 import com.jillesvangurp.geojson.asFeature
@@ -70,7 +69,7 @@ class MapAlignmentTest {
                         if (!seen.contains(providerPair)) {
                             println(
                                 "| $refProvider | ${refPoint.latitude}, ${refPoint.longitude} | $otherProvider | ${otherPoint.latitude}, ${otherPoint.longitude} | ${
-                                    GeoGeometry.distance(
+                                    distance(
                                         refPoint,
                                         otherPoint
                                     ).roundDecimals(2)

--- a/src/commonTest/kotlin/com/jillesvangurp/geogeometry/RotateScaleTranslateTest.kt
+++ b/src/commonTest/kotlin/com/jillesvangurp/geogeometry/RotateScaleTranslateTest.kt
@@ -1,6 +1,6 @@
 package com.jillesvangurp.geogeometry
 
-import com.jillesvangurp.geo.GeoGeometry
+import com.jillesvangurp.geogeometry.geometry.*
 import com.jillesvangurp.geojson.*
 import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldContainInOrder
@@ -17,17 +17,17 @@ class RotationTest {
 
     @Test
     fun shouldTranslateCircle() {
-        val circle = GeoGeometry.circle2polygon(20, rosenthalerPlatz.latitude, rosenthalerPlatz.longitude, 20.0)
+        val circle = circle2polygon(20, rosenthalerPlatz.latitude, rosenthalerPlatz.longitude, 20.0)
             .polygonGeometry()
 
         val moved = circle.translate(oranienburgerTor.geometry())
 
         // we'll allow a few meters deviation. Earth is not perfectly spherical
-        GeoGeometry.distance(oranienburgerTor, moved.centroid()) shouldBeLessThan 10.0
+        distance(oranienburgerTor, moved.centroid()) shouldBeLessThan 10.0
         moved as Geometry.Polygon
         moved.outerCoordinates.forEach {
             // radius of the circle should be similar, it will change a little
-            val radius = GeoGeometry.distance(moved.centroid(), it)
+            val radius = distance(moved.centroid(), it)
             radius shouldBeGreaterThan 19.0
             radius shouldBeLessThan 21.0
         }
@@ -37,16 +37,16 @@ class RotationTest {
     fun scaleXShouldScaleCorrectly() {
         val rectangle = rectangle(brandenBurgerGate, 70.0)
         var cs = rectangle.coordinates!!
-        GeoGeometry.distance(cs[0][0], cs[0][1]).roundToLong() shouldBe 70
-        GeoGeometry.distance(cs[0][1], cs[0][2]).roundToLong() shouldBe 70
+        distance(cs[0][0], cs[0][1]).roundToLong() shouldBe 70
+        distance(cs[0][1], cs[0][2]).roundToLong() shouldBe 70
         cs = rectangle.scaleX(30.0).coordinates!!
-        GeoGeometry.distance(cs[0][0], cs[0][1]).roundToLong() shouldBe (70.0 * 0.3).toLong()
+        distance(cs[0][0], cs[0][1]).roundToLong() shouldBe (70.0 * 0.3).toLong()
         cs = rectangle.scaleX(130.0).coordinates!!
-        GeoGeometry.distance(cs[0][0], cs[0][1]).roundToLong() shouldBe (70.0 * 1.3).toLong()
+        distance(cs[0][0], cs[0][1]).roundToLong() shouldBe (70.0 * 1.3).toLong()
         cs = rectangle.scaleY(30.0).coordinates!!
-        GeoGeometry.distance(cs[0][1], cs[0][2]).roundToLong() shouldBe (70.0 * 0.3).toLong()
+        distance(cs[0][1], cs[0][2]).roundToLong() shouldBe (70.0 * 0.3).toLong()
         cs = rectangle.scaleY(130.0).coordinates!!
-        GeoGeometry.distance(cs[0][1], cs[0][2]).roundToLong() shouldBe (70.0 * 1.3).toLong()
+        distance(cs[0][1], cs[0][2]).roundToLong() shouldBe (70.0 * 1.3).toLong()
     }
 
     @Test
@@ -97,15 +97,15 @@ class RotationTest {
     @Test
     fun shouldMoveInRightDirection() {
 
-        val circle = GeoGeometry.circle2polygon(20, rosenthalerPlatz.latitude, rosenthalerPlatz.longitude, 20.0)
+        val circle = circle2polygon(20, rosenthalerPlatz.latitude, rosenthalerPlatz.longitude, 20.0)
             .polygonGeometry()
         listOf(
-            GeoGeometry.translate(circle.centroid().latitude, circle.centroid().longitude, 0.0, 50.0),
-            GeoGeometry.translate(circle.centroid().latitude, circle.centroid().longitude, 50.0, 0.0),
-            GeoGeometry.translate(circle.centroid().latitude, circle.centroid().longitude, -50.0, 0.0),
-            GeoGeometry.translate(circle.centroid().latitude, circle.centroid().longitude, 0.0, -50.0),
+            translate(circle.centroid().latitude, circle.centroid().longitude, 0.0, 50.0),
+            translate(circle.centroid().latitude, circle.centroid().longitude, 50.0, 0.0),
+            translate(circle.centroid().latitude, circle.centroid().longitude, -50.0, 0.0),
+            translate(circle.centroid().latitude, circle.centroid().longitude, 0.0, -50.0),
         ).forEach { point ->
-            GeoGeometry.distance(circle.translate(Geometry.Point(point)).centroid(), point) shouldBeLessThan 1.0
+            distance(circle.translate(Geometry.Point(point)).centroid(), point) shouldBeLessThan 1.0
         }
     }
 
@@ -113,13 +113,13 @@ class RotationTest {
     fun shouldRotate() {
         val anchor = bergstr16Berlin
         val point = oranienburgerTor
-        val d = GeoGeometry.distance(anchor, point)
+        val d = distance(anchor, point)
         val points = (0..240).step(10).map {
-            GeoGeometry.rotateAround(anchor, point, it.toDouble())
+            rotateAround(anchor, point, it.toDouble())
         }
             .also {
                 // all points should be the same distance
-                it.forEach { (GeoGeometry.distance(bergstr16Berlin, it) - d).absoluteValue shouldBeLessThan 0.1 }
+                it.forEach { (distance(bergstr16Berlin, it) - d).absoluteValue shouldBeLessThan 0.1 }
                 it.size shouldBe 25
                 it.distinct().size shouldBe 25
                 it.contains(bergstr16Berlin) shouldBe false
@@ -137,8 +137,8 @@ class RotationTest {
     fun rotateByZeroDegreesShouldBeSamePoint() {
         val anchor = bergstr16Berlin
         val point = oranienburgerTor
-        GeoGeometry.distance(point, GeoGeometry.rotateAround(anchor, point, 0.0)) shouldBeLessThan 1.0
-        (GeoGeometry.distance(point, GeoGeometry.rotateAround(anchor, point, 180.0)) - 2 * GeoGeometry.distance(
+        distance(point, rotateAround(anchor, point, 0.0)) shouldBeLessThan 1.0
+        (distance(point, rotateAround(anchor, point, 180.0)) - 2 * distance(
             anchor,
             point
         )).absoluteValue shouldBeLessThan 1.0
@@ -146,9 +146,9 @@ class RotationTest {
 
     @Test
     fun shouldTranslateCorrectly() {
-        val translated = GeoGeometry.translate(52.530564, 13.394964, 1000.0, 3000.0)
+        val translated = translate(52.530564, 13.394964, 1000.0, 3000.0)
         val pythagorasDistance = sqrt(1000.0.pow(2.0) + 3000.0.pow(2.0))
-        val distance = GeoGeometry.distance(lonLat(13.394964, 52.530564), translated)
+        val distance = distance(lonLat(13.394964, 52.530564), translated)
         withClue("distance should be correct for translated coordinate") {
             abs(distance - pythagorasDistance) shouldBeLessThan 1.0
         }
@@ -157,7 +157,7 @@ class RotationTest {
     @Test
     fun shouldRotatePointAround() {
         val around = moritzPlatz
-        val distance = GeoGeometry.distance(around, rosenthalerPlatz)
+        val distance = distance(around, rosenthalerPlatz)
 
         val rotatedPoints = (0..36).map { d ->
             rosenthalerPlatz.rotate(d.toDouble() * 10, around).geometry().asFeatureWithProperties {
@@ -167,7 +167,7 @@ class RotationTest {
             }
         }
         rotatedPoints.forEach {
-            val actualDistance = GeoGeometry.distance(around, (it.geometry as Geometry.Point).coordinates!!)
+            val actualDistance = distance(around, (it.geometry as Geometry.Point).coordinates!!)
             withClue("$actualDistance is too different from expected $distance") {
                 abs(actualDistance - distance) shouldBeLessThan 1.0
             }
@@ -226,8 +226,8 @@ class RotationTest {
         }
         triangle.outerSegments.zip(rotated.outerSegments).forEach { (originalSegment, rotatedSegment) ->
             // verify segments have same length as the original even after rotating many times
-            val ogLength = GeoGeometry.distance(originalSegment[0], originalSegment[1])
-            val rotatedLength = GeoGeometry.distance(rotatedSegment[0], rotatedSegment[1])
+            val ogLength = distance(originalSegment[0], originalSegment[1])
+            val rotatedLength = distance(rotatedSegment[0], rotatedSegment[1])
             ogLength - rotatedLength shouldBeLessThan 1.0
         }
 
@@ -242,7 +242,7 @@ class RotationTest {
     @Test
     fun shouldMoveBackAndForth() {
         val moved = rosenthalerPlatz.translate(-1000.0,-2000.0).translate(1000.0,2000.0)
-        GeoGeometry.distance(rosenthalerPlatz,moved) shouldBeLessThan 1.0
+        distance(rosenthalerPlatz,moved) shouldBeLessThan 1.0
     }
 
 

--- a/src/commonTest/kotlin/com/jillesvangurp/geogeometry/UTMTest.kt
+++ b/src/commonTest/kotlin/com/jillesvangurp/geogeometry/UTMTest.kt
@@ -1,7 +1,7 @@
 package com.jillesvangurp.geogeometry
 
 import com.jillesvangurp.geo.*
-import com.jillesvangurp.geo.GeoGeometry.Companion.roundDecimals
+import com.jillesvangurp.geogeometry.geometry.*
 import com.jillesvangurp.geojson.*
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrowAny
@@ -137,7 +137,7 @@ class UTMTest {
                     val utm = original.toUtmCoordinate()
                     val converted = utm.utmToPointCoordinates()
                     val distance =
-                        GeoGeometry.distance(original.latitude, original.longitude, converted[1], converted[0])
+                        distance(original.latitude, original.longitude, converted[1], converted[0])
 
                     distance shouldBeLessThanOrEqual marginOfError
                 }

--- a/src/commonTest/kotlin/com/jillesvangurp/geogeometry/helpers.kt
+++ b/src/commonTest/kotlin/com/jillesvangurp/geogeometry/helpers.kt
@@ -2,7 +2,7 @@
 
 package com.jillesvangurp.geogeometry
 
-import com.jillesvangurp.geojson.PointCoordinates
+import com.jillesvangurp.geogeometry.core.PointCoordinates
 import com.jillesvangurp.serializationext.DEFAULT_JSON
 import io.kotest.matchers.doubles.shouldBeLessThan
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -10,8 +10,10 @@ import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlin.math.abs
 
+import com.jillesvangurp.geogeometry.geometry.*
+
 infix fun PointCoordinates.shouldBeNear(expected: PointCoordinates) {
-    val distance = com.jillesvangurp.geo.GeoGeometry.distance(this,expected)
+    val distance = distance(this,expected)
     distance shouldBeLessThan 1.0
 }
 

--- a/src/commonTest/kotlin/com/jillesvangurp/geojson/GeoJsonExtensionsTest.kt
+++ b/src/commonTest/kotlin/com/jillesvangurp/geojson/GeoJsonExtensionsTest.kt
@@ -1,6 +1,6 @@
 package com.jillesvangurp.geojson
 
-import com.jillesvangurp.geo.GeoGeometry
+import com.jillesvangurp.geogeometry.geometry.*
 import com.jillesvangurp.geogeometry.oranienburgerTor
 import com.jillesvangurp.geogeometry.rosenthalerPlatz
 import io.kotest.matchers.doubles.shouldBeGreaterThan
@@ -14,7 +14,7 @@ class GeoJsonExtensionsTest {
 
     @Test
     fun shouldCreateTriangle() {
-        GeoGeometry.circle2polygon(3, rosenthalerPlatz.latitude, rosenthalerPlatz.longitude, 20.0)
+        circle2polygon(3, rosenthalerPlatz.latitude, rosenthalerPlatz.longitude, 20.0)
             .polygonGeometry().let {
                 println(it)
             }

--- a/src/commonTest/kotlin/com/jillesvangurp/geojson/GeojsonTest.kt
+++ b/src/commonTest/kotlin/com/jillesvangurp/geojson/GeojsonTest.kt
@@ -1,6 +1,6 @@
 package com.jillesvangurp.geojson
 
-import com.jillesvangurp.geo.GeoGeometry
+import com.jillesvangurp.geogeometry.geometry.*
 import com.jillesvangurp.geo.GeoHashUtils
 import com.jillesvangurp.geogeometry.bergstr16Berlin
 import com.jillesvangurp.serializationext.DEFAULT_JSON
@@ -22,13 +22,13 @@ class GeojsonKtTest {
     fun shouldCalculateZoomLevel() {
         val meters = 75.0
 
-        val zl1 = GeoGeometry.bbox(
+        val zl1 = bbox(
             bergstr16Berlin.latitude, bergstr16Berlin.longitude,
             meters,
             meters
         ).zoomLevel()
 
-        val zl2 = GeoGeometry.bbox(
+        val zl2 = bbox(
             bergstr16Berlin.latitude, bergstr16Berlin.longitude,
             meters * 16,
             meters * 16
@@ -46,12 +46,12 @@ class GeojsonKtTest {
     @Test
     fun shouldTile() {
 
-        val bbox = GeoGeometry.bbox(
+        val bbox = bbox(
             bergstr16Berlin.latitude, bergstr16Berlin.longitude,
             100.0 * 16,
             100.0 * 16
         )
-        val cells = GeoGeometry.calculateTileBboxesForBoundingBox(bbox)
+        val cells = calculateTileBboxesForBoundingBox(bbox)
         val collection =
             FeatureCollection(cells.map { it.polygon() }.map { it.asFeature() } + listOf(bbox.polygon().asFeature()))
         val json = collection.toString()
@@ -354,8 +354,8 @@ class GeojsonKtTest {
 
     @Test
     fun nestedCircleShouldIntersect() {
-        val c1 = GeoGeometry.circle2polygon(50, 52.0, 13.0, 10.0).asGeometry
-        val c2 = GeoGeometry.circle2polygon(50, 52.0, 13.0, 5.0).asGeometry
+        val c1 = circle2polygon(50, 52.0, 13.0, 10.0).asGeometry
+        val c2 = circle2polygon(50, 52.0, 13.0, 5.0).asGeometry
 
         c1.intersects(c2) shouldBe true
         c2.intersects(c1) shouldBe true
@@ -363,16 +363,16 @@ class GeojsonKtTest {
 
     @Test
     fun testPolygonContainmentRespectHoles() {
-        val outer = GeoGeometry.circle2polygon(50, 52.0, 13.0, 10.0)[0]
-        val inner = GeoGeometry.circle2polygon(50, 52.0, 13.0, 5.0)[0]
+        val outer = circle2polygon(50, 52.0, 13.0, 10.0)[0]
+        val inner = circle2polygon(50, 52.0, 13.0, 5.0)[0]
         val poly = arrayOf(outer, inner).asGeometry
         assertSoftly {
             poly.randomPoints().take(2000).forEach {
                 withClue("outer should contain ${it.latitude} ${it.longitude}") {
-                    GeoGeometry.polygonContains(it, outer) shouldBe true
+                    polygonContains(it, outer) shouldBe true
                 }
                 withClue("inner should not contain ${it.latitude} ${it.longitude}") {
-                    GeoGeometry.polygonContains(it, inner) shouldBe false
+                    polygonContains(it, inner) shouldBe false
                 }
                 withClue("geometry should contain ${it.latitude} ${it.longitude}") {
                     poly.contains(it) shouldBe true


### PR DESCRIPTION
## Summary
- create `core` module with geometry type aliases and constants
- move geometry operations to new package and remove `GeoGeometry` class
- update library and tests to use new packages

## Testing
- `./gradlew build --no-daemon` *(failed: Could not resolve google.d8:v8)*

------
https://chatgpt.com/codex/tasks/task_e_6847d2714188832e89b0ba667954ad1f